### PR TITLE
docs: add AGENTS.md, serial protocol docs, and comprehensive README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# esphome-bspool-chlorinator
+
+ESPHome external component for **BSPool VA Salt (Smart)** salt-water chlorinator. Communicates over UART (RS232-TTL) using a proprietary 3-byte request/response protocol.
+
+## Quick Start
+
+```bash
+# Build test (ESP8266, Arduino framework)
+# Requires ESPHome CLI installed
+esphome compile tests/components/bs_pool/test.esp8266-ard.yaml
+
+# Usage: add as external component in your ESPHome YAML
+# See example.yaml for full configuration
+```
+
+## Architecture
+
+```
+esphome/components/bs_pool/        # All source code lives here
+├── __init__.py + bs_pool.{h,cpp}  # Core: BSPool hub, BSPoolListener, DataPacket, FunctionCode
+├── sensor/                        # 7 measurement sensors
+├── binary_sensor/                 # 21 status/alarm/warning binary sensors
+├── switch/                        # 8 user settings switches
+├── select/                        # 1 control mode select
+└── text_sensor/                   # 2 text sensors (time, version)
+
+tests/components/bs_pool/          # Build tests (ESP8266)
+PCB/                               # Hardware: schematics, BOM, wiring (read-only reference)
+```
+
+### Core Pattern
+
+**Listener-based polling**: `BSPool` (PollingComponent + UARTDevice) polls the chlorinator every 60s. Each sub-component registers as a `BSPoolListener` and declares which `FunctionCode`s it needs via `codes_to_poll()`. Responses are dispatched to all listeners via `handle_message(DataPacket&)`.
+
+### Sub-component Structure (repeated 5×)
+
+Every entity type (sensor, binary_sensor, switch, select, text_sensor) follows the same pattern:
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | ESPHome config schema + `to_code()` codegen |
+| `bs_pool_X.h` | C++ class: BSPoolListener + Component, SUB_* macros |
+| `bs_pool_X.cpp` | `codes_to_poll()` + `handle_message()` with switch on function_code |
+
+Switch and select additionally have child classes (`UserSettingsSwitch`, `ControlModeSelect`) using `Parented<BSPool>` for write-back to the UART bus.
+
+## Protocol
+
+- **Baud**: 19200
+- **Request**: `{'?', function_code, '\4'}` (3 bytes)
+- **Response**: `{function_code, data_b2, data_b3}` (3 bytes)
+- **DataPacket**: union of `{function_code, data_b2, data_b3}` and raw `uint8_t data[3]`
+
+### Function Codes
+
+| Code | Name | Usage |
+|------|------|-------|
+| `'r'` | USER | User settings bitfield |
+| `'m'` | CONTROL_MODE | Manual/Auto/Semi-auto |
+| `'A'` | ALARMS | Alarm bitmask |
+| `'w'` | WARNINGS | Warning bitmask |
+| `'s'` | STATUS | Status bitmask |
+| `'c'`/`'C'`/`'V'`/`'p'`/`'N'`/`'o'`/`'W'` | Measurements | Various sensor values |
+| `'H'` | TIME | Clock |
+| `'y'` | VERSION | Firmware version |
+
+## Conventions
+
+- **Language**: C++ (Arduino/ESP8266), Python (ESPHome codegen)
+- **Commits**: Conventional Commits in English (`feat:`, `fix:`, `chore:`)
+- **Branch**: `main`
+- **No CI/CD, no linter, no formatter** — early-stage project
+- **Hardware target**: ESP8266 NodeMCU + RS232-TTL converter + DC-DC 5V step-down
+- **Test**: Build-only test via `esphome compile` (no unit tests)
+
+## Key Gotchas
+
+- **Sensor scaling**: cell_current/voltage → `/10.0f`, pH/salt → `/100.0f`, radox → raw mV
+- **Invalid values**: pH and salt report `0xFFFF` when unavailable → publish `NAN`
+- **Temperature sign**: `data_b3` flag controls sign of temperature
+- **Inverted switch bits**: `is_outdoor` (bit0), `ph_alarm` (bit4), `ph_control` (bit6) use inverted logic
+- **TODO**: `bs_pool_switch.cpp:34` — unverified bit for `cover_switch_off`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,105 @@
-# esphome-bspool-chlorinator
-ESPHome configuration to read data from solinator BSPool VA Salt (Smart)
+# ESPHome BSPool Chlorinator
+
+ESPHome external component for the BSPool VA Salt (Smart) salt-water chlorinator.
+
+## What is this
+
+An ESPHome external component that connects to the BSPool VA Salt (Smart) chlorinator over RS232 (UART) using its proprietary 3-byte request/response protocol. It exposes sensors, binary sensors, switches, a control mode select, and text sensors directly to Home Assistant without any custom firmware flashing or cloud dependency.
+
+## Supported entities
+
+**7 sensors**
+- Cell current, cell intensity, cell voltage, pH, salt concentration, ORP (redox), temperature
+
+**21 binary sensors**
+- 7 alarms: ORP probe saturated, overtemperature, open circuit, water flow, short circuit, P954 unit stopped, communication error to P954
+- 6 warnings: low salt, high salt, pH pump overrun, acid, clock set, probe disconnected
+- 8 status flags: output voltage polarity, filter pump running, chlorination in process, stopped by remote, ORP sensor stable, salt sensor connected, electrode cleaning, super-chlorination
+
+**8 switches** (user settings)
+- Outdoor, cover switch off, flow switch installed, ORP displayed, pH alarm, pH corrector alkaline, pH control, cover installed
+
+**1 select**
+- Control mode: Manual / Automatic / Semi-automatic
+
+**2 text sensors**
+- Device time, firmware version
+
+## Installation
+
+Add the component as an external source in your ESPHome YAML:
+
+```yaml
+external_components:
+  - source:
+      type: git
+      url: https://github.com/lipov3cz3k/esphome-bspool-chlorinator
+    components: [ bs_pool ]
+```
+
+## Configuration
+
+Minimal working configuration for ESP8266:
+
+```yaml
+external_components:
+  - source:
+      type: git
+      url: https://github.com/lipov3cz3k/esphome-bspool-chlorinator
+    components: [ bs_pool ]
+
+uart:
+  tx_pin: GPIO1
+  rx_pin: GPIO3
+  baud_rate: 19200
+
+bs_pool:
+  update_interval: 60s
+
+sensor:
+  - platform: bs_pool
+    temperature:
+      name: "Pool Temperature"
+```
+
+See [example.yaml](example.yaml) for the full configuration with all available entities.
+
+## Hardware
+
+- ESP8266 NodeMCU V3
+- RS232-to-TTL converter module
+- DC-DC step-down converter (set to 5V)
+
+You can wire the components together on a breadboard or any other way you prefer. A simple custom PCB that connects all the parts is also available in the [`PCB/`](PCB/) directory.
+
+```
+                          ┌──────────────┐
+  Chlorinator             │  RS232-TTL   │          ┌──────────────┐
+  ┌─────────┐   RS232     │  Converter   │   UART   │   ESP8266    │
+  │         ├────────────►│              │          │   NodeMCU    │
+  │  BSPool │  Left ───── │ RX       TX ─┼─────────►│ GPIO3 (RX)   │
+  │ VA Salt │  Middle ─── │ TX       RX ─┼◄─────────│ GPIO1 (TX)   │
+  │         │  Right ──── │ GND     GND ─┼──────────│ GND          │
+  └────┬────┘             │         VCC ─┼──┐       └──────┬───────┘
+       │                  └──────────────┘  │              │
+       │ 12V                                │ 5V           │ 5V
+       │              ┌──────────────┐      │              │
+       └─────────────►│   DC-DC      ├──────┴──────────────┘
+                      │  Step-Down   │
+                      │  (set 5V!)   │
+                      └──────────────┘
+```
+
+The full schematic is available in [`PCB/`](PCB/).
+
+## Protocol documentation
+
+See [Serial Protocol Documentation](docs/serial-protocol.md) for the full communication protocol reference.
+
+## Disclaimer
+
+This project is provided as-is, without any warranty. It has been tested on a single device only. Use at your own risk. The author assumes no responsibility for any damage to your equipment, pool, or anything else resulting from using this component.
+
+## License
+
+GPL-3.0 -- see [LICENSE](LICENSE)

--- a/docs/serial-protocol.md
+++ b/docs/serial-protocol.md
@@ -1,0 +1,180 @@
+# BSPool Chlorinator Serial Protocol
+
+> For software version 70 or higher.
+
+## Communication Parameters
+
+| Parameter      | Value  |
+|----------------|--------|
+| Baud rate      | 19200  |
+| Data bits      | 8      |
+| Parity         | None   |
+| Stop bits      | 1      |
+| Flow control   | None   |
+| Frame size     | 3 bytes (always) |
+| Max inter-byte delay | 10 ms (incomplete frames are discarded) |
+
+## Master / Slave Model
+
+- The **remote controller is the master** — the chlorinator is a slave and never sends data unsolicited.
+
+## Frame Format
+
+### Request (master → chlorinator)
+
+```
+Byte 0: '?' (0x3F)
+Byte 1: function_code (B1)
+Byte 2: EOT (0x04)
+```
+
+### Response (chlorinator → master)
+
+```
+Byte 0: function_code (B1) — echo of requested code
+Byte 1: data_b2 (B2)
+Byte 2: data_b3 (B3)
+```
+
+### Write Command (master → chlorinator)
+
+```
+Byte 0: function_code (B1) — parameter to change
+Byte 1: data low byte (B2)
+Byte 2: data high byte (B3)
+```
+
+Response: same format as read response. Out-of-range values are rejected.
+
+### Error Response
+
+```
+Byte 0: 'E' (0x45)
+Byte 1: 'R' (0x52)
+Byte 2: error code (n)
+```
+
+| Error code | Meaning |
+|------------|---------|
+| 1 | Unknown command (first byte) |
+| 2 | Unknown parameter (2nd byte after `'?'`) |
+| 3 | Timeout error |
+
+---
+
+## P906 Function Codes
+
+### Device Info
+
+| B1 | Description | Unit | Writable | B2 | B3 |
+|----|-------------|------|----------|----|----|
+| `'Z'` (0x5A) | Chlorinator size/type | — | No | 0=P927 10g/h<br>1=P927 15g/h<br>2=P950 20g/h<br>3=P950 25g/h<br>4=P953 35g/h<br>5=P956 50g/h<br>6=P956 70g/h<br>7=P957 100g/h<br>8=P957 150g/h<br>9=P954 200g/h<br>10=P910 35g/h<br>11=P910 50g/h<br>12=P910 70g/h<br>13=P910 100g/h<br>14=P910 200g/h | EOT (0x04) |
+| `'y'` (0x79) | Software version | — | No | Version integer part | Version decimal part |
+
+### Settings
+
+| B1 | Description | Unit | Writable | B2 | B3 |
+|----|-------------|------|----------|----|----|
+| `'L'` (0x4C) | Language | — | Yes | 0=English<br>1=Spanish<br>2=Catalan<br>3=French<br>4=Italian<br>5=Dutch<br>6=Portuguese<br>7=Turkish<br>8=Hebrew<br>9=German<br>10=Czech | EOT (0x04) |
+| `'v'` (0x76) | Swimming pool volume | 1 m³ | Yes | Volume low byte | Volume high byte |
+| `'m'` (0x6D) | Control mode | — | Yes | 0=Manual<br>1=Automatic<br>2=Semi-automatic | EOT (0x04) |
+| `'b'` (0x62) | Cleaning cycle | 10 min | Yes | Delay (minutes/10) | EOT (0x04) |
+| `'T'` (0x54) | Select power 0–100% | % | Yes | Power | EOT (0x04) |
+| `'S'` (0x53) | Stop/Start (also stops pH pump, clears alarms) | — | Yes | 0=Start, 1=Stop | EOT (0x04) |
+| `'r'` (0x72) | User settings bitfield | — | Yes | Bit 0: 0=Outdoors / 1=Indoors<br>Bit 1: 0=Cover switch ON when cover ON / 1=OFF<br>Bit 2: 0=Flow switch not installed / 1=Installed<br>Bit 3: 0=ORP not displayed / 1=Displayed<br>Bit 4: 0=pH alarm active / 1=Off<br>Bit 5: 0=pH corrector acid / 1=Alkaline<br>Bit 6: 0=pH control on / 1=Off<br>Bit 7: 0=Cover not installed / 1=Installed | EOT (0x04) |
+| `'P'` (0x50) | pH target (×100, e.g. 7.10 → 710) | — | Yes | pH low byte | pH high byte |
+
+### Alarms, Warnings & Status
+
+| B1 | Description | Unit | Writable | B2 | B3 |
+|----|-------------|------|----------|----|----|
+| `'A'` (0x41) | Alarm bitmask | — | No | Bit 0: ORP probe saturated<br>Bit 1: Overtemperature<br>Bit 2: Open circuit<br>Bit 3: Lack of water flow<br>Bit 4: Short circuit<br>Bit 5: P954 unit stopped<br>Bit 6: Communication error to P954 | EOT (0x04) |
+| `'w'` (0x77) | Warning flags | — | No | Bit 2: Too few salt<br>Bit 3: Too much salt | Bit 0: pH pump overrun<br>Bit 1: Acid warning<br>Bit 2: Clock has been set<br>Bit 3: ORP/chlorine probe disconnected |
+| `'s'` (0x73) | Status bitmask | — | No | Bit 0: Polarity of output voltage<br>Bit 1: Filter pump running<br>Bit 2: Chlorination in process<br>Bit 3: Stopped by remote controller<br>Bit 4: ORP sensor reading is stable<br>Bit 5: Salt sensor connected<br>Bit 6: Electrode cleaning in process<br>Bit 7: Super-chlorination in process | EOT (0x04) |
+
+### Measurements
+
+| B1 | Description | Unit | Scaling | B2 | B3 |
+|----|-------------|------|---------|----|----|
+| `'c'` (0x63) | Cell current | 100 mA | ÷10 → Amps | I low byte | I high byte |
+| `'C'` (0x43) | Cell intensity (% of max) | % | Raw | Percent | EOT (0x04) |
+| `'V'` (0x56) | Cell voltage | 100 mV | ÷10 → Volts | V low byte | V high byte |
+| `'p'` (0x70) | pH measurement | 0.01 pH | ÷100 → pH | pH low byte | pH high byte |
+| `'N'` (0x4E) | Salt concentration | g/l × 100 | ÷100 → g/l | Salt low byte | Salt high byte |
+| `'o'` (0x6F) | Current ORP value | mV | Raw | ORP low byte | ORP high byte |
+| `'W'` (0x57) | Water temperature | 1°C | Raw (signed) | Temperature | Sign (0=+, 1=−) |
+
+**Special values:**
+- pH (`'p'`): `B2=0xFF, B3=0xFF` → sensor not connected
+- Salt (`'N'`): `B2=0xFF, B3=0xFF` → sensor not connected
+- Temperature (`'W'`): `B2=0xFF, B3=0x01` → sensor not connected
+- ORP (`'o'`): accepts values up to `0x7FF`
+
+**ORP / Free Chlorine dual reading:**
+- `'O'` (0x4F) — **target** ORP (writable): B2=ORP low, B3=ORP high. For free chlorine: B2=ppm×100, B3=`0b10000000`
+- `'o'` (0x6F) — **current** ORP (read-only): B2=ORP low, B3=ORP high. For free chlorine: B3 highest bit set (`0b1xxxxxxx`), remaining = ppm high
+
+### Time & Hours of Operation
+
+| B1 | Description | Writable | B2 | B3 |
+|----|-------------|----------|----|----|
+| `'H'` (0x48) | Current time | Yes | Minutes (0–59) | Hours (0–23) |
+| `'F'` (0x46) | Hours of operation (low) | No | Minutes (0–59) | Hours low byte |
+| `'G'` (0x47) | Hours of operation (high) | No | Hours middle byte | Hours high byte |
+
+### Relay Control
+
+| B1 | Description | Writable | B2 | B3 |
+|----|-------------|----------|----|----|
+| `'R'` (0x52) | Relay status | Yes | Read: 0=off, 1=on<br>Write: 0=set OFF, 1=set ON, 2=timed ON, 3=1 cycle/24h, 4=2 cycles/24h | EOT (0x04) |
+| `'D'` (0x44) | Relay delay (when status=1) | Yes | Minutes | EOT (0x04) |
+| 201 | Program 1 start time | Yes | Minutes | Hours |
+| 202 | Program 1 stop time | Yes | Minutes | Hours |
+| 203 | Program 2 start time | Yes | Minutes | Hours |
+| 204 | Program 2 stop time | Yes | Minutes | Hours |
+
+### P954 Multi-Unit Readings (numeric B1)
+
+| B1 | Description | Unit |
+|----|-------------|------|
+| 131 | Cell intensity %, P954 unit 1 | % |
+| 132 | Cell intensity %, P954 unit 2 | % |
+| 133 | Cell intensity %, P954 unit 3 | % |
+| 134 | Cell intensity %, P954 unit 4 | % |
+| 141 | Cell voltage ×10, P954 unit 1 | 100 mV |
+| 142 | Cell voltage ×10, P954 unit 2 | 100 mV |
+| 143 | Cell voltage ×10, P954 unit 3 | 100 mV |
+| 144 | Cell voltage ×10, P954 unit 4 | 100 mV |
+| 211 | Hours of operation, P954 unit 1 | Hours |
+| 212 | Hours of operation, P954 unit 2 | Hours |
+| 213 | Hours of operation, P954 unit 3 | Hours |
+| 214 | Hours of operation, P954 unit 4 | Hours |
+
+---
+
+## P913 Function Codes
+
+The P913 chlorinator uses a subset/variant of the P906 protocol.
+
+### P913-specific Differences
+
+| B1 | Description | B2 | B3 |
+|----|-------------|----|----|
+| `'L'` | Language (same as P906 but without Czech) | 0–9 | EOT (0x04) |
+| `'m'` | Control mode | 0=Manual<br>1=Automatic (no Semi-auto) | EOT (0x04) |
+| `'T'` | Select power 0–100% | % Power | EOT (0x04) |
+| `'C'` | Selected power 0–100% (read-only) | % Power | EOT (0x04) |
+
+### P913 Alarms, Warnings & User Settings
+
+| B1 | Description | Unit | Writable | B2 | B3 |
+|----|-------------|------|----------|----|----|
+| `'A'` | Alarm bitmask | — | No | Bit 0: ORP problem — pump overrun<br>Bit 3: Lack of water flow | EOT (0x04) |
+| `'w'` | Warning flags | — | No | Bit 0: pH problem — pump overrun | EOT (0x04) |
+| `'r'` | User settings bitfield | — | Yes | Bit 2: 0=Flow switch disabled / 1=Enabled<br>Bit 3: 0=ORP not displayed / 1=Displayed<br>Bit 5: 0=pH corrector acid / 1=Alkaline<br>Bit 6: 0=pH control enabled / 1=Disabled<br>Bit 7: 0=Chlorine control enabled / 1=Disabled | EOT (0x04) |
+
+### P913 Shared Commands
+
+Same as P906: `'O'`, `'o'`, `'P'`, `'p'`, `'F'`, `'G'`, `'y'`
+
+

--- a/esphome/components/bs_pool/AGENTS.md
+++ b/esphome/components/bs_pool/AGENTS.md
@@ -1,0 +1,128 @@
+# bs_pool Component
+
+ESPHome external component implementing the BSPool chlorinator UART protocol.
+
+## Module Layout
+
+```
+__init__.py + bs_pool.{h,cpp}   # Hub: BSPool, BSPoolListener, DataPacket, FunctionCode
+sensor/                          # 7 sensors (cell_current, cell_intensity, cell_voltage, ph, salt, radox, temp)
+binary_sensor/                   # 21 binary sensors (7 alarms, 6 warnings, 8 statuses)
+switch/                          # 8 user settings switches (bitfield on FunctionCode::USER)
+select/                          # 1 select: control_mode (FunctionCode::CONTROL_MODE)
+text_sensor/                     # 2 text sensors: time (FunctionCode::TIME), version (FunctionCode::VERSION)
+```
+
+## Adding a New Entity
+
+1. **Create sub-directory** with `__init__.py`, `bs_pool_X.h`, `bs_pool_X.cpp`
+2. **Python schema** (`__init__.py`):
+   - Define `CONFIG_SCHEMA` with `cv.Optional` fields keyed by entity name
+   - `async def to_code(config)` → `cg.new_Pvariable()`, set parent, `register_listener()`
+3. **C++ header** (`bs_pool_X.h`):
+   - Inherit `BSPoolListener` + `Component`
+   - Use `SUB_SENSOR` / `SUB_BINARY_SENSOR` / `SUB_SWITCH` / `SUB_TEXT_SENSOR` macros for each entity
+4. **C++ source** (`bs_pool_X.cpp`):
+   - `codes_to_poll()` → return vector of `FunctionCode`s this component needs
+   - `handle_message(DataPacket &packet)` → switch on `packet.function_code`, decode, `publish_state()`
+5. **For writable entities** (switch/select): add write helper methods in the component and send UART commands with `parent_->write_array({code, b2, b3})` + `flush()`
+
+### Checklist
+
+- [ ] Add `CONF_*` constant in `__init__.py` if not in `esphome.const`
+- [ ] Register as listener in `to_code()`: `cg.add(hub.register_listener(var))`
+- [ ] Add new entries to `tests/components/bs_pool/common.yaml`
+- [ ] Verify with `esphome compile tests/components/bs_pool/test.esp8266-ard.yaml`
+
+## Protocol Details
+
+### Data Decoding Patterns
+
+```cpp
+// Simple uint16 from B2/B3 (B2 = low byte, B3 = high byte)
+uint16_t raw = (packet.data_b3 << 8) | packet.data_b2;
+
+// Scaled float (cell_current, cell_voltage)
+float value = raw / 10.0f;
+
+// Scaled float (pH, salt_concentration)
+float value = raw / 100.0f;
+
+// Invalid marker (pH, salt only)
+if (raw == 0xFFFF) { publish_state(NAN); return; }
+
+// Signed temperature (data_b3 bit controls sign)
+float temp = packet.data_b2;
+if (packet.data_b3) temp = -temp;
+
+// Bitmask (alarms/status in B2; warnings split across B2/B3)
+bool flag = packet.data_b2 & (1 << BIT_POSITION);
+
+// User settings bitfield (switch)
+bool setting = packet.data_b2 & (1 << BIT_POSITION);
+// INVERTED bits: is_outdoor(bit0), ph_alarm(bit4), ph_control(bit6)
+```
+
+### Writing Data (switch/select)
+
+```cpp
+// BSPoolSwitch::send_user_state()
+// Pack all 8 user setting bits into B2 and send full USER bitfield
+parent_->write_array({FunctionCode::USER, packed_user_settings_b2, '\4'});
+parent_->flush();
+
+// BSPoolSelect::send_command(FunctionCode::CONTROL_MODE, mode_value)
+parent_->write_array({FunctionCode::CONTROL_MODE, mode_value, '\4'});
+parent_->flush();
+```
+
+## Bitmask Maps
+
+### Alarms (FunctionCode::ALARMS = `'A'`, data_b2)
+
+| Bit | Name | Description |
+|-----|------|-------------|
+| 0 | `alarm_redox_saturated` | ORP probe saturated |
+| 1 | `alarm_overtemperature` | Overtemperature inside chlorinator |
+| 2 | `alarm_open_circuit` | Open circuit |
+| 3 | `alarm_water_flow` | Lack of water flow |
+| 4 | `alarm_short_circuit` | Short circuit |
+| 5 | `alarm_unit_stopped` | P954 unit stopped |
+| 6 | `alarm_communication_error` | Communication error to P954 |
+
+### Warnings (FunctionCode::WARNINGS = `'w'`)
+
+| Bit | Name | Description |
+|-----|------|-------------|
+| B2.2 | `warning_low_salt` | Too few salt |
+| B2.3 | `warning_high_salt` | Too much salt |
+| B3.0 | `warning_ph_pump_overrun` | pH problem — pump has run too long |
+| B3.1 | `warning_acid` | Acid warning |
+| B3.2 | `warning_clock_set` | Clock has been set |
+| B3.3 | `warning_probe_disconnected` | ORP/chlorine probe disconnected |
+
+### Status (FunctionCode::STATUS = `'s'`, data_b2)
+
+| Bit | Name |
+|-----|------|
+| 0 | `status_output_voltage_polarity` |
+| 1 | `status_filter_pump_running` |
+| 2 | `status_chlorination_process` |
+| 3 | `status_stopped_by_remote` |
+| 4 | `status_orp_sensor_stable` |
+| 5 | `status_salt_sensor_connected` |
+| 6 | `status_electrode_cleaning` |
+| 7 | `status_super_chlorination` |
+
+### User Settings (FunctionCode::USER = `'r'`, data_b2)
+
+| Bit | Name | Inverted? |
+|-----|------|-----------|
+| 0 | `is_outdoor` | ✓ |
+| 1 | `cover_switch_off` | ✗ (TODO: unverified) |
+| 2 | `flow_switch_installed` | ✗ |
+| 3 | `orp_displayed` | ✗ |
+| 4 | `ph_alarm` | ✓ |
+| 5 | `ph_corrector_alkaline` | ✗ |
+| 6 | `ph_control` | ✓ |
+| 7 | `cover_installed` | ✗ |


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` (root + component-level) with architecture overview, protocol details, and contributor guide
- Add `docs/serial-protocol.md` with full P906/P913 communication protocol reference
- Rewrite `README.md` with supported entities, installation, configuration example, ASCII wiring diagram, disclaimer, and license