### PR TITLE
ci: add compile test workflow for ESP8266

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: ESP8266
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install ESPHome
+        run: pip install esphome
+      - name: Validate config
+        run: esphome config tests/components/bs_pool/test.esp8266-ard.yaml
+      - name: Build firmware
+        uses: esphome/build-action@v7
+        with:
+          yaml-file: tests/components/bs_pool/test.esp8266-ard.yaml

--- a/tests/components/bs_pool/test.esp8266-ard.yaml
+++ b/tests/components/bs_pool/test.esp8266-ard.yaml
@@ -2,4 +2,22 @@ substitutions:
   tx_pin: GPIO4
   rx_pin: GPIO5
 
+esphome:
+  name: test-bs-pool-esp8266
+
+esp8266:
+  board: nodemcuv2
+
+external_components:
+  - source:
+      type: local
+      path: ../../../esphome/components
+    components: [bs_pool]
+
+wifi:
+  ssid: "TestSSID"
+  password: "TestPassword"
+
+logger:
+
 <<: !include common.yaml


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow using official `esphome/build-action@v7`
- Config validation (`esphome config`) before firmware build
- ESP8266 (`nodemcuv2`) compile test — the only tested board
- Triggered on push to `main` and pull requests, with concurrency group to cancel duplicate builds